### PR TITLE
Fix package environment reference and add Author/Maintainer fields

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,9 @@ Authors@R: c(
     person("Billsfriend", role = c("cre", "ctb"), 
            email = "Billsfriend1999@outlook.com",
            comment = "OpenMP parallelization and performance optimizations"))
+Author: Xiaojie Qiu [aut], Cole Trapnell [aut], Qi Mao [aut], Li Wang [aut],
+    Billsfriend [cre, ctb] (OpenMP parallelization and performance optimizations)
+Maintainer: Billsfriend <Billsfriend1999@outlook.com>
 Depends: irlba
 Imports: Rcpp
 LinkingTo: Rcpp, RcppEigen, BH

--- a/src/DDRTree.cpp
+++ b/src/DDRTree.cpp
@@ -179,7 +179,7 @@ void DDRTree_reduce_dim_cpp(const MatrixXd& X_in,
     MatrixXd C(X_in.rows(), X_in.cols());
     MatrixXd tmp1(X_in.rows(), X_in.rows());
 
-    Environment stats("package:DDRTree");
+    Environment stats("package:DDRTree2");
     Function pca_projection_R = stats["pca_projection_R"];
 
     Function get_major_eigenvalue = stats["get_major_eigenvalue"];


### PR DESCRIPTION
Critical Fixes:
- Fixed Environment reference in src/DDRTree.cpp:
  * Changed 'package:DDRTree' to 'package:DDRTree2'
  * This was causing examples to fail with error: 'no item called "package:DDRTree" on the search list'

- Added required Author and Maintainer fields to DESCRIPTION:
  * R CMD check requires these fields even with Authors@R
  * Author: Lists all contributors with roles
  * Maintainer: Billsfriend <Billsfriend1999@outlook.com>

Testing:
- Package builds successfully: R CMD INSTALL
- Examples run without errors
- R CMD check passes (examples OK)
- Verified with iris dataset example

This fixes the runtime error where the C++ code tried to access functions from the old package namespace.